### PR TITLE
Fix history/killer move-ordering heuristics and time management

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -100,6 +100,20 @@ impl Board {
             .map(|(mv, _)| *mv)
     }
 
+    /// Number of plies (half-moves) played so far in the game.
+    ///
+    /// Ply 0 is the starting position (white to move, fullmove 1).
+    /// Derived from the fullmove counter and side to move rather than
+    /// tracked separately, so it stays in sync with FEN parsing and
+    /// make/unmake without extra bookkeeping.
+    pub fn ply(&self) -> u32 {
+        let base = (self.fullmove_number.saturating_sub(1)) as u32 * 2;
+        match self.side_to_move {
+            Color::White => base,
+            Color::Black => base + 1,
+        }
+    }
+
     pub fn castling_rights(&self) -> CastlingRights {
         self.castling_rights
     }

--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -91,6 +91,15 @@ impl Board {
         self.side_to_move
     }
 
+    /// Get the most recently made move, if move history tracking is enabled
+    /// (see [`Board::enable_history`]) and at least one move has been made.
+    pub fn last_move(&self) -> Option<Move> {
+        self.move_history
+            .as_ref()
+            .and_then(|history| history.last())
+            .map(|(mv, _)| *mv)
+    }
+
     pub fn castling_rights(&self) -> CastlingRights {
         self.castling_rights
     }

--- a/src/search/history.rs
+++ b/src/search/history.rs
@@ -15,10 +15,14 @@ use crate::types::Color;
 /// Maximum history score before scaling.
 pub const MAX_HISTORY_SCORE: i32 = 16384;
 
-/// History bonus formula: depth * depth
+/// History bonus formula: linear in depth (Stockfish-style).
+///
+/// `300 * depth - 250`, clamped to be non-negative and capped at
+/// `MAX_HISTORY_SCORE` so a single update can never exceed the table's
+/// own ceiling.
 #[inline]
 fn history_bonus(depth: i32) -> i32 {
-    depth * depth
+    (300 * depth - 250).clamp(0, MAX_HISTORY_SCORE)
 }
 
 /// History table for quiet move ordering.
@@ -87,7 +91,8 @@ impl HistoryTable {
     pub fn update_penalty(&mut self, color: Color, mv: &Move, depth: i32) {
         let from = mv.from.index();
         let to = mv.to.index();
-        let penalty = history_bonus(depth);
+        // Penalize less aggressively than we reward: half the bonus magnitude.
+        let penalty = history_bonus(depth) / 2;
 
         // Apply penalty with gravity scaling.
         let current = self.history[color as usize][from][to];
@@ -205,6 +210,96 @@ impl Default for CounterMoveTable {
     }
 }
 
+/// Continuation history heuristic.
+///
+/// A magnitude-aware extension of [`CounterMoveTable`]: instead of storing a
+/// single "best reply" per previous move, it scores *every* candidate move as
+/// a reply to the opponent's previous move, using the same gravity-scaled
+/// update as [`HistoryTable`]. This preserves diversity that a single-slot
+/// counter move table loses.
+///
+/// Indexed by `[previous_move.piece_type][previous_move.to_square]` for the
+/// opponent's move, then `[mv.from_square][mv.to_square]` for our candidate
+/// reply.
+///
+/// Conceptually indexed as `[piece_type; 6][to_square; 64][from_square; 64][to_square; 64]`,
+/// but stored as a flat heap-allocated buffer (via `vec!`) to avoid
+/// constructing a ~6 MiB nested array on the stack.
+pub struct ContinuationHistory {
+    /// Flat continuation scores, indexed via [`Self::index`].
+    scores: Vec<i32>,
+}
+
+/// Dimensions of the conceptual `[piece_type][prev_to][from][to]` table.
+const CH_PIECE_TYPES: usize = 6;
+const CH_SQUARES: usize = 64;
+const CH_SIZE: usize = CH_PIECE_TYPES * CH_SQUARES * CH_SQUARES * CH_SQUARES;
+
+impl ContinuationHistory {
+    /// Create a new empty continuation history table.
+    pub fn new() -> Self {
+        Self {
+            scores: vec![0; CH_SIZE],
+        }
+    }
+
+    /// Clear all continuation history scores (call at start of new game).
+    pub fn clear(&mut self) {
+        for score in &mut self.scores {
+            *score = 0;
+        }
+    }
+
+    #[inline]
+    fn index(previous_move: &Move, mv: &Move) -> usize {
+        let piece_type = previous_move.piece.piece_type as usize;
+        let prev_to = previous_move.to.index();
+        let from = mv.from.index();
+        let to = mv.to.index();
+        ((piece_type * CH_SQUARES + prev_to) * CH_SQUARES + from) * CH_SQUARES + to
+    }
+
+    /// Get the continuation history score for `mv` as a reply to
+    /// `previous_move`.
+    #[inline]
+    pub fn get(&self, previous_move: &Move, mv: &Move) -> i32 {
+        self.scores[Self::index(previous_move, mv)]
+    }
+
+    /// Update the continuation history score for `mv` as a reply to
+    /// `previous_move`.
+    ///
+    /// Uses the same gravity-scaling approach as [`HistoryTable`]: a bonus
+    /// for the move that caused the cutoff, a smaller-magnitude penalty for
+    /// quiet moves that were tried and failed.
+    ///
+    /// # Arguments
+    /// * `previous_move` - The opponent's move we're responding to.
+    /// * `mv` - The candidate reply being scored.
+    /// * `depth` - The remaining search depth.
+    /// * `is_bonus` - `true` to reward (cutoff move), `false` to penalize
+    ///   (failed quiet move).
+    pub fn update(&mut self, previous_move: &Move, mv: &Move, depth: i32, is_bonus: bool) {
+        let idx = Self::index(previous_move, mv);
+
+        let delta = if is_bonus {
+            history_bonus(depth)
+        } else {
+            -(history_bonus(depth) / 2)
+        };
+
+        let current = self.scores[idx];
+        let new_score = current + delta - (current * delta.abs() / MAX_HISTORY_SCORE);
+        self.scores[idx] = new_score.clamp(-MAX_HISTORY_SCORE, MAX_HISTORY_SCORE);
+    }
+}
+
+impl Default for ContinuationHistory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,7 +339,7 @@ mod tests {
 
         let score = table.get(Color::White, &mv);
         assert!(score > 0, "Score should be positive after cutoff: {}", score);
-        assert_eq!(score, 25); // depth * depth = 5 * 5 = 25
+        assert_eq!(score, 1250); // 300 * depth - 250 = 300 * 5 - 250 = 1250
     }
 
     #[test]
@@ -443,5 +538,117 @@ mod tests {
 
         assert_eq!(table.get(&prev1), Some(counter1));
         assert_eq!(table.get(&prev2), Some(counter2));
+    }
+
+    // ==================== ContinuationHistory Tests ====================
+
+    #[test]
+    fn test_new_continuation_history_is_zero() {
+        let table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        assert_eq!(table.get(&prev, &mv), 0);
+    }
+
+    #[test]
+    fn test_continuation_history_bonus_increases_score() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        table.update(&prev, &mv, 5, true);
+
+        let score = table.get(&prev, &mv);
+        assert!(score > 0, "Score should be positive after bonus update: {}", score);
+    }
+
+    #[test]
+    fn test_continuation_history_penalty_decreases_score() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        table.update(&prev, &mv, 5, false);
+
+        let score = table.get(&prev, &mv);
+        assert!(score < 0, "Score should be negative after penalty update: {}", score);
+    }
+
+    #[test]
+    fn test_continuation_history_clamped() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        for _ in 0..1000 {
+            table.update(&prev, &mv, 20, true);
+        }
+
+        let score = table.get(&prev, &mv);
+        assert!(
+            score <= MAX_HISTORY_SCORE,
+            "Score should be clamped: {} <= {}",
+            score,
+            MAX_HISTORY_SCORE
+        );
+    }
+
+    #[test]
+    fn test_continuation_history_clamped_negative() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        for _ in 0..1000 {
+            table.update(&prev, &mv, 20, false);
+        }
+
+        let score = table.get(&prev, &mv);
+        assert!(
+            score >= -MAX_HISTORY_SCORE,
+            "Score should be clamped: {} >= {}",
+            score,
+            -MAX_HISTORY_SCORE
+        );
+    }
+
+    #[test]
+    fn test_continuation_history_previous_move_independent() {
+        let mut table = ContinuationHistory::new();
+        let prev1 = make_move("e7", "e5", PieceType::Pawn);
+        let prev2 = make_move("d7", "d5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        table.update(&prev1, &mv, 5, true);
+
+        assert!(table.get(&prev1, &mv) > 0);
+        assert_eq!(table.get(&prev2, &mv), 0);
+    }
+
+    #[test]
+    fn test_continuation_history_current_move_independent() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv1 = make_move("g1", "f3", PieceType::Knight);
+        let mv2 = make_move("d2", "d4", PieceType::Pawn);
+
+        table.update(&prev, &mv1, 5, true);
+
+        assert!(table.get(&prev, &mv1) > 0);
+        assert_eq!(table.get(&prev, &mv2), 0);
+    }
+
+    #[test]
+    fn test_continuation_history_clear() {
+        let mut table = ContinuationHistory::new();
+        let prev = make_move("e7", "e5", PieceType::Pawn);
+        let mv = make_move("g1", "f3", PieceType::Knight);
+
+        table.update(&prev, &mv, 10, true);
+        assert!(table.get(&prev, &mv) > 0);
+
+        table.clear();
+        assert_eq!(table.get(&prev, &mv), 0);
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -32,7 +32,7 @@ mod move_ordering;
 mod time_manager;
 mod transposition;
 
-pub use history::{CounterMoveTable, HistoryTable};
+pub use history::{ContinuationHistory, CounterMoveTable, HistoryTable};
 pub use killer_moves::KillerMoveTable;
 pub use move_ordering::{is_good_capture, order_captures, MoveOrderer, ScoredMove};
 pub use time_manager::{SearchLimits, TimeControl, TimeManager};
@@ -159,6 +159,8 @@ pub struct SearchEngine {
     history: HistoryTable,
     /// Counter move table.
     counters: CounterMoveTable,
+    /// Continuation history (magnitude-scored "move B replies to move A").
+    continuation_history: ContinuationHistory,
     /// Position evaluator.
     evaluator: Evaluator,
     /// Time manager.
@@ -177,6 +179,7 @@ impl SearchEngine {
             killers: KillerMoveTable::new(),
             history: HistoryTable::new(),
             counters: CounterMoveTable::new(),
+            continuation_history: ContinuationHistory::new(),
             evaluator: Evaluator::new(),
             time_manager: TimeManager::default(),
             stats: SearchStats::default(),
@@ -198,6 +201,7 @@ impl SearchEngine {
         self.killers.clear();
         self.history.clear();
         self.counters.clear();
+        self.continuation_history.clear();
         self.stats.reset();
         self.pv_table.clear();
     }
@@ -213,11 +217,10 @@ impl SearchEngine {
         // Store max depth from limits.
         let max_depth = limits.max_depth;
 
-        // Age history table for fresh search.
-        self.history.age();
-
-        // Clear killers for new search.
-        self.killers.clear();
+        // NOTE: History and killer tables are intentionally NOT reset here.
+        // They should persist across searches within the same game so that
+        // move-ordering knowledge accumulated on earlier moves is retained.
+        // A full reset only happens in `new_game()`.
 
         // Increment TT age.
         self.tt.new_search();
@@ -435,13 +438,18 @@ impl SearchEngine {
             }
         }
 
+        // The opponent's previous move (if any), used for continuation history.
+        let previous_move = board.last_move();
+
         // Create move orderer and collect all moves in order.
-        let mut orderer = MoveOrderer::new(
+        let mut orderer = MoveOrderer::with_continuation_history(
             board,
             moves,
             hash_move,
             &self.killers,
             &self.history,
+            &self.continuation_history,
+            previous_move,
             ply,
         );
 
@@ -539,7 +547,14 @@ impl SearchEngine {
 
                         // Update heuristics for quiet moves.
                         if !is_capture {
-                            self.update_cutoff_heuristics(board, &mv, depth, ply, &quiets_tried);
+                            self.update_cutoff_heuristics(
+                                board,
+                                &mv,
+                                depth,
+                                ply,
+                                &quiets_tried,
+                                previous_move,
+                            );
                         }
 
                         // Store in TT with adjusted mate score.
@@ -782,6 +797,7 @@ impl SearchEngine {
         depth: i32,
         ply: u8,
         quiets_tried: &[Move],
+        previous_move: Option<Move>,
     ) {
         let color = board.side_to_move();
 
@@ -790,6 +806,18 @@ impl SearchEngine {
 
         // Update history heuristic.
         self.history.update(color, mv, quiets_tried, depth);
+
+        // Update continuation history: reward the cutoff move, penalize the
+        // quiet moves that were tried first and failed, both keyed on the
+        // opponent's previous move.
+        if let Some(prev) = previous_move {
+            self.continuation_history.update(&prev, mv, depth, true);
+            for failed in quiets_tried {
+                if failed != mv {
+                    self.continuation_history.update(&prev, failed, depth, false);
+                }
+            }
+        }
     }
 
     /// Extract principal variation from the transposition table.

--- a/src/search/move_ordering.rs
+++ b/src/search/move_ordering.rs
@@ -18,11 +18,16 @@ use crate::types::{Color, PieceType, Square};
 use crate::Board;
 use once_cell::sync::Lazy;
 
-use super::history::HistoryTable;
+use super::history::{ContinuationHistory, HistoryTable};
 use super::killer_moves::KillerMoveTable;
 
 /// Lazy-initialized attack table for SEE calculations.
 static ATTACK_TABLE: Lazy<AttackTable> = Lazy::new(AttackTable::new);
+
+/// Shared empty continuation history used by [`MoveOrderer::new`], which
+/// doesn't take a continuation history table (e.g. in tests or call sites
+/// that don't track the previous move).
+static EMPTY_CONTINUATION_HISTORY: Lazy<ContinuationHistory> = Lazy::new(ContinuationHistory::new);
 
 /// Score constants for move ordering.
 pub mod scores {
@@ -91,6 +96,10 @@ pub struct MoveOrderer<'a> {
     killers: &'a KillerMoveTable,
     /// Reference to history table.
     history: &'a HistoryTable,
+    /// Reference to continuation history table.
+    continuation_history: &'a ContinuationHistory,
+    /// The opponent's previous move, if known (absent at the root).
+    previous_move: Option<Move>,
     /// Current ply for killer move lookup.
     ply: u8,
 }
@@ -113,12 +122,50 @@ impl<'a> MoveOrderer<'a> {
         history: &'a HistoryTable,
         ply: u8,
     ) -> Self {
+        Self::with_continuation_history(
+            board,
+            moves,
+            hash_move,
+            killers,
+            history,
+            &EMPTY_CONTINUATION_HISTORY,
+            None,
+            ply,
+        )
+    }
+
+    /// Create a new move orderer, additionally scoring quiet moves with
+    /// continuation history (how good `mv` has historically been as a reply
+    /// to `previous_move`).
+    ///
+    /// # Arguments
+    /// * `board` - The current position
+    /// * `moves` - Legal moves to order
+    /// * `hash_move` - Best move from transposition table (if any)
+    /// * `killers` - Killer move table reference
+    /// * `history` - History table reference
+    /// * `continuation_history` - Continuation history table reference
+    /// * `previous_move` - The opponent's previous move, if known
+    /// * `ply` - Current search ply
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_continuation_history(
+        board: &Board,
+        moves: Vec<Move>,
+        hash_move: Option<Move>,
+        killers: &'a KillerMoveTable,
+        history: &'a HistoryTable,
+        continuation_history: &'a ContinuationHistory,
+        previous_move: Option<Move>,
+        ply: u8,
+    ) -> Self {
         let mut orderer = Self {
             moves: moves.into_iter().map(|mv| ScoredMove::new(mv, 0)).collect(),
             current: 0,
             hash_move,
             killers,
             history,
+            continuation_history,
+            previous_move,
             ply,
         };
         orderer.score_moves(board);
@@ -170,8 +217,15 @@ impl<'a> MoveOrderer<'a> {
                 continue;
             }
 
-            // Quiet moves use history heuristic.
-            scored_move.score = scores::QUIET_BASE + self.history.get(color, mv);
+            // Quiet moves use history heuristic, plus continuation history
+            // (how good this move has been as a reply to the previous move).
+            // Both live on the same MAX_HISTORY_SCORE scale, so they're
+            // simply added together.
+            let continuation_score = match &self.previous_move {
+                Some(prev) => self.continuation_history.get(prev, mv),
+                None => 0,
+            };
+            scored_move.score = scores::QUIET_BASE + self.history.get(color, mv) + continuation_score;
         }
     }
 

--- a/src/search/time_manager.rs
+++ b/src/search/time_manager.rs
@@ -27,6 +27,25 @@ const SOFT_LIMIT_FRACTION: f64 = 0.6;
 /// Minimum time to allocate (1 millisecond).
 const MIN_TIME_MS: u64 = 1;
 
+/// Fixed estimate of network/GUI latency (move overhead) to subtract from
+/// every computed hard limit, so we don't risk flagging on time due to
+/// communication delay with the GUI. Not yet exposed via UCI `setoption`.
+const DEFAULT_MOVE_OVERHEAD_MS: u64 = 50;
+
+/// Coefficient controlling how quickly the base time allocation shrinks as
+/// the game progresses. Applied as `1 / (1 + PLY_SCALE_COEFFICIENT *
+/// ln(1 + ply))`, loosely inspired by Stockfish's logarithmic time-scale
+/// heuristic: early in the game (low ply) the scale factor is close to
+/// 1.0, and it decreases smoothly (monotonically) as more plies are
+/// played, since fewer of the originally-assumed moves remain and we
+/// should stop reserving as much time per move.
+const PLY_SCALE_COEFFICIENT: f64 = 0.15;
+
+/// Lower bound on the ply-based scale factor. Guarantees the scale factor
+/// (and therefore the time budget) never approaches zero, even for very
+/// long games.
+const MIN_PLY_SCALE: f64 = 0.4;
+
 /// Time control mode for the search.
 #[derive(Clone, Debug)]
 pub enum TimeControl {
@@ -42,6 +61,9 @@ pub enum TimeControl {
         increment: Duration,
         /// Estimated moves until time control (None for sudden death).
         moves_to_go: Option<u32>,
+        /// Plies (half-moves) played so far in the game, for ply-aware
+        /// scaling of the base time allocation.
+        ply: u32,
     },
     /// Infinite search until stopped.
     Infinite,
@@ -87,12 +109,22 @@ impl SearchLimits {
     }
 
     /// Create limits for a game clock.
-    pub fn game_clock(remaining_ms: u64, increment_ms: u64, moves_to_go: Option<u32>) -> Self {
+    ///
+    /// `ply` is the number of plies (half-moves) already played in the
+    /// game, used to scale the base time allocation (see
+    /// [`TimeManager::calculate_time_budget`]).
+    pub fn game_clock(
+        remaining_ms: u64,
+        increment_ms: u64,
+        moves_to_go: Option<u32>,
+        ply: u32,
+    ) -> Self {
         Self {
             time_control: TimeControl::GameClock {
                 remaining: Duration::from_millis(remaining_ms),
                 increment: Duration::from_millis(increment_ms),
                 moves_to_go,
+                ply,
             },
             max_depth: None,
             max_nodes: None,
@@ -168,8 +200,10 @@ impl TimeManager {
                 remaining,
                 increment,
                 moves_to_go,
+                ply,
             } => {
-                let (soft, hard) = Self::calculate_time_budget(*remaining, *increment, *moves_to_go);
+                let (soft, hard) =
+                    Self::calculate_time_budget(*remaining, *increment, *moves_to_go, *ply);
                 (soft, hard, true)
             }
             TimeControl::Infinite => {
@@ -200,7 +234,7 @@ impl TimeManager {
     /// Start the clock for a new search.
     pub fn start(&mut self) {
         self.start_time = Instant::now();
-        self.stopped.store(false, Ordering::Relaxed);
+        self.stopped.store(false, Ordering::Release);
         self.nodes_searched = 0;
     }
 
@@ -210,7 +244,7 @@ impl TimeManager {
     #[inline]
     pub fn should_stop(&self) -> bool {
         // Check stop flag first (fastest).
-        if self.stopped.load(Ordering::Relaxed) {
+        if self.stopped.load(Ordering::Acquire) {
             return true;
         }
 
@@ -235,7 +269,7 @@ impl TimeManager {
     /// Uses the soft limit to make this decision.
     #[inline]
     pub fn can_start_iteration(&self) -> bool {
-        if self.stopped.load(Ordering::Relaxed) {
+        if self.stopped.load(Ordering::Acquire) {
             return false;
         }
 
@@ -249,13 +283,13 @@ impl TimeManager {
 
     /// Signal that the search should stop immediately.
     pub fn stop(&mut self) {
-        self.stopped.store(true, Ordering::Relaxed);
+        self.stopped.store(true, Ordering::Release);
     }
 
     /// Check if the search has been manually stopped.
     #[inline]
     pub fn is_stopped(&self) -> bool {
-        self.stopped.load(Ordering::Relaxed)
+        self.stopped.load(Ordering::Acquire)
     }
 
     /// Get elapsed time since search start.
@@ -282,22 +316,39 @@ impl TimeManager {
         self.nodes_searched
     }
 
+    /// Compute the ply-based scale factor applied to the base time
+    /// allocation (see [`Self::calculate_time_budget`]).
+    ///
+    /// `1 / (1 + PLY_SCALE_COEFFICIENT * ln(1 + ply))`, clamped to
+    /// `MIN_PLY_SCALE`. Monotonically non-increasing in `ply`, always in
+    /// `(0, 1]`, so it can never zero out or invert the time budget.
+    fn ply_scale(ply: u32) -> f64 {
+        let raw = 1.0 / (1.0 + PLY_SCALE_COEFFICIENT * (1.0 + ply as f64).ln());
+        raw.max(MIN_PLY_SCALE)
+    }
+
     /// Calculate time allocation for a game clock.
     ///
     /// Uses a simple but effective formula:
-    /// - Base time = remaining / moves_to_go
+    /// - Base time = (remaining / moves_to_go) scaled down as the game
+    ///   progresses (see [`Self::ply_scale`]), so early moves don't
+    ///   over-allocate and later moves don't under-allocate relative to a
+    ///   shrinking pool of assumed remaining moves.
     /// - Add a fraction of the increment
-    /// - Soft limit = base time * SOFT_LIMIT_FRACTION
-    /// - Hard limit = min(base time, remaining * MAX_TIME_FRACTION)
+    /// - Hard limit = min(base time, remaining * MAX_TIME_FRACTION) minus a
+    ///   fixed move-overhead reserve for GUI/network latency
+    /// - Soft limit = hard limit * SOFT_LIMIT_FRACTION
     ///
     /// # Arguments
     /// * `remaining` - Time remaining on clock
     /// * `increment` - Time increment per move
     /// * `moves_to_go` - Moves until time control (None for sudden death)
+    /// * `ply` - Plies (half-moves) already played in the game
     fn calculate_time_budget(
         remaining: Duration,
         increment: Duration,
         moves_to_go: Option<u32>,
+        ply: u32,
     ) -> (Duration, Duration) {
         let remaining_ms = remaining.as_millis() as f64;
         let increment_ms = increment.as_millis() as f64;
@@ -305,15 +356,19 @@ impl TimeManager {
         // Estimate moves remaining.
         let moves = moves_to_go.unwrap_or(DEFAULT_MOVES_TO_GO) as f64;
 
-        // Base allocation: remaining time divided by expected moves.
-        let base_time_ms = remaining_ms * TIME_FRACTION + remaining_ms / moves;
+        // Base allocation: remaining time divided by expected moves, scaled
+        // by how far into the game we are.
+        let base_time_ms =
+            (remaining_ms * TIME_FRACTION + remaining_ms / moves) * Self::ply_scale(ply);
 
         // Add increment (use most of it, save a bit for overhead).
         let with_increment_ms = base_time_ms + increment_ms * 0.9;
 
-        // Hard limit: don't use more than MAX_TIME_FRACTION of remaining time.
+        // Hard limit: don't use more than MAX_TIME_FRACTION of remaining
+        // time, and reserve a fixed move-overhead for GUI/network latency.
         let max_time_ms = remaining_ms * MAX_TIME_FRACTION;
-        let hard_limit_ms = with_increment_ms.min(max_time_ms).max(MIN_TIME_MS as f64);
+        let hard_limit_ms = (with_increment_ms.min(max_time_ms) - DEFAULT_MOVE_OVERHEAD_MS as f64)
+            .max(MIN_TIME_MS as f64);
 
         // Soft limit: fraction of hard limit.
         let soft_limit_ms = (hard_limit_ms * SOFT_LIMIT_FRACTION).max(MIN_TIME_MS as f64);
@@ -442,8 +497,8 @@ mod tests {
 
     #[test]
     fn test_game_clock_allocation() {
-        // 1 minute remaining, 1 second increment, 20 moves to go.
-        let limits = SearchLimits::game_clock(60_000, 1_000, Some(20));
+        // 1 minute remaining, 1 second increment, 20 moves to go, early game.
+        let limits = SearchLimits::game_clock(60_000, 1_000, Some(20), 1);
         let tm = TimeManager::new(&limits);
 
         assert!(tm.use_time_limit);
@@ -463,8 +518,8 @@ mod tests {
 
     #[test]
     fn test_game_clock_sudden_death() {
-        // 30 seconds remaining, no increment, sudden death.
-        let limits = SearchLimits::game_clock(30_000, 0, None);
+        // 30 seconds remaining, no increment, sudden death, early game.
+        let limits = SearchLimits::game_clock(30_000, 0, None, 1);
         let tm = TimeManager::new(&limits);
 
         let hard_ms = tm.hard_limit().as_millis();
@@ -479,8 +534,8 @@ mod tests {
 
     #[test]
     fn test_game_clock_with_increment() {
-        // 10 seconds remaining, 5 second increment.
-        let limits = SearchLimits::game_clock(10_000, 5_000, None);
+        // 10 seconds remaining, 5 second increment, early game.
+        let limits = SearchLimits::game_clock(10_000, 5_000, None, 1);
         let tm = TimeManager::new(&limits);
 
         let hard_ms = tm.hard_limit().as_millis();
@@ -626,10 +681,54 @@ mod tests {
     #[test]
     fn test_minimum_time_allocation() {
         // Very short time - should still allocate at least MIN_TIME_MS.
-        let limits = SearchLimits::game_clock(10, 0, Some(100));
+        let limits = SearchLimits::game_clock(10, 0, Some(100), 1);
         let tm = TimeManager::new(&limits);
 
         assert!(tm.soft_limit().as_millis() >= MIN_TIME_MS as u128);
         assert!(tm.hard_limit().as_millis() >= MIN_TIME_MS as u128);
+    }
+
+    #[test]
+    fn test_ply_scaling_is_monotonic() {
+        // Same clock/increment/moves_to_go, but a much later ply should
+        // never allocate more time than an early ply.
+        let early = SearchLimits::game_clock(60_000, 1_000, Some(20), 1);
+        let late = SearchLimits::game_clock(60_000, 1_000, Some(20), 300);
+
+        let tm_early = TimeManager::new(&early);
+        let tm_late = TimeManager::new(&late);
+
+        assert!(
+            tm_late.soft_limit() <= tm_early.soft_limit(),
+            "Later ply should not increase the soft limit: early={:?} late={:?}",
+            tm_early.soft_limit(),
+            tm_late.soft_limit()
+        );
+        assert!(
+            tm_late.hard_limit() <= tm_early.hard_limit(),
+            "Later ply should not increase the hard limit: early={:?} late={:?}",
+            tm_early.hard_limit(),
+            tm_late.hard_limit()
+        );
+    }
+
+    #[test]
+    fn test_endgame_ply_budget_stays_sane() {
+        // Deep into the game (ply 300), the budget must still be positive
+        // and bounded by the hard time fraction of remaining time.
+        let limits = SearchLimits::game_clock(30_000, 0, None, 300);
+        let tm = TimeManager::new(&limits);
+
+        let soft_ms = tm.soft_limit().as_millis();
+        let hard_ms = tm.hard_limit().as_millis();
+
+        assert!(soft_ms >= MIN_TIME_MS as u128, "Soft limit must stay positive at ply 300");
+        assert!(hard_ms >= MIN_TIME_MS as u128, "Hard limit must stay positive at ply 300");
+        assert!(hard_ms > soft_ms, "Hard limit should exceed soft limit at ply 300");
+        assert!(
+            hard_ms <= 7_500,
+            "Should still be conservative in sudden death at ply 300: {}",
+            hard_ms
+        );
     }
 }

--- a/src/uci/handler.rs
+++ b/src/uci/handler.rs
@@ -261,6 +261,7 @@ impl UciEngine {
                 time,
                 increment.unwrap_or(0),
                 params.movestogo,
+                self.board.ply(),
             );
             if let Some(depth) = params.depth {
                 limits = limits.with_depth(depth);


### PR DESCRIPTION
## Summary
Addresses 7 findings from a code review of the search heuristics and time management:

**History/killer heuristics** (`src/search/history.rs`, `src/search/killer_moves.rs`, `src/search/mod.rs`):
- Replace quadratic `depth*depth` history bonus with Stockfish's linear `300*depth - 250`, and use a distinct (halved) penalty magnitude instead of sharing the bonus formula.
- Stop calling `history.age()` / `killers.clear()` on every `search()` call — these now only reset via `new_game()`, so move-ordering knowledge persists across moves within a game instead of being thrown away every move.
- Add a `ContinuationHistory` table (keyed by opponent's previous move → current move) wired into move ordering and cutoff updates, additive alongside the existing single-slot `CounterMoveTable`.

**Time management** (`src/search/time_manager.rs`, `src/board/mod.rs`, `src/uci/handler.rs`):
- Make the game-clock time budget ply-aware (logarithmic scale-down as the game progresses) and subtract a fixed move-overhead margin (50ms) from the hard limit.
- Switch the cross-thread stop flag from `Ordering::Relaxed` to `Acquire`/`Release` for correct happens-before visibility between the UCI stop handler and the search thread.

Documentation-only findings (killer/history tables not thread-safe / not thread-local) were not code changes — the engine is single-threaded today; noted as a consideration if Lazy SMP is ever added.

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test --workspace` — 167 passed, 4 failed (pre-existing `book::tests::*` failures unrelated to this change — missing opening-book binary in this environment, confirmed present before these changes via `git stash`)
- [x] `cargo clippy` on touched files — no new warnings/errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)